### PR TITLE
Feature/compatibility engine

### DIFF
--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/CompatibilityEngine.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/CompatibilityEngine.java
@@ -1,0 +1,24 @@
+package gr.A4.SmartHouseBuilder.engine;
+
+import gr.A4.SmartHouseBuilder.model.SetupBuild;
+import gr.A4.SmartHouseBuilder.model.ValidationResult;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CompatibilityEngine {
+
+    private final List<IValidationRule> rules = List.of(new EcosystemMatchRule(),new HubRequirementRule());
+
+    public List<ValidationResult> runAllChecks(SetupBuild build) {
+        List<ValidationResult> results = new ArrayList<>();
+
+        for (IValidationRule rule : rules) {
+            results.add(rule.validate(build));
+        }
+
+        return results;
+    }
+}

--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/EcosystemMatchRule.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/EcosystemMatchRule.java
@@ -1,0 +1,40 @@
+package gr.A4.SmartHouseBuilder.engine;
+
+import gr.A4.SmartHouseBuilder.model.PlacedDevice;
+import gr.A4.SmartHouseBuilder.model.SetupBuild;
+import gr.A4.SmartHouseBuilder.model.ValidationResult;
+
+public class EcosystemMatchRule implements IValidationRule {
+
+    @Override
+    public ValidationResult validate(SetupBuild build) {
+        if (build == null) {
+            return new ValidationResult(false, "ERROR", "SetupBuild este null.");
+        }
+
+        if (build.getTargetEcosystem() == null || build.getTargetEcosystem().isBlank()) {
+            return new ValidationResult(false, "ERROR", "Ecosistemul țintă lipsește.");
+        }
+
+        if (build.getDevices() == null || build.getDevices().isEmpty()) {
+            return new ValidationResult(true, "INFO", "Nu există device-uri de verificat.");
+        }
+
+        String target = build.getTargetEcosystem().trim();
+
+        for (PlacedDevice placedDevice : build.getDevices()) {
+            if (placedDevice == null || placedDevice.getDevice() == null) {
+                return new ValidationResult(false, "ERROR", "Există un device invalid în listă.");
+            }
+
+            String ecosystem = placedDevice.getDevice().getEcosystem();
+            if (ecosystem == null || !target.equalsIgnoreCase(ecosystem.trim())) {
+                String deviceName = placedDevice.getDevice().getName();
+
+                return new ValidationResult(false, "ERROR", "Device-ul '" + deviceName + "' nu este compatibil cu ecosistemul țintă '" + target + "'.");
+            }
+        }
+
+        return new ValidationResult(true, "INFO", "Toate device-urile sunt compatibile cu ecosistemul țintă.");
+    }
+}

--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/EcosystemMatchRule.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/EcosystemMatchRule.java
@@ -9,32 +9,32 @@ public class EcosystemMatchRule implements IValidationRule {
     @Override
     public ValidationResult validate(SetupBuild build) {
         if (build == null) {
-            return new ValidationResult(false, "ERROR", "SetupBuild este null.");
+            return new ValidationResult(false, "ERROR", "SetupBuild is null.");
         }
 
         if (build.getTargetEcosystem() == null || build.getTargetEcosystem().isBlank()) {
-            return new ValidationResult(false, "ERROR", "Ecosistemul țintă lipsește.");
+            return new ValidationResult(false, "ERROR", "Target Ecosystem is missing.");
         }
 
         if (build.getDevices() == null || build.getDevices().isEmpty()) {
-            return new ValidationResult(true, "INFO", "Nu există device-uri de verificat.");
+            return new ValidationResult(true, "INFO", "There are no devices to check.");
         }
 
         String target = build.getTargetEcosystem().trim();
 
         for (PlacedDevice placedDevice : build.getDevices()) {
             if (placedDevice == null || placedDevice.getDevice() == null) {
-                return new ValidationResult(false, "ERROR", "Există un device invalid în listă.");
+                return new ValidationResult(false, "ERROR", "Invalid device given.");
             }
 
             String ecosystem = placedDevice.getDevice().getEcosystem();
             if (ecosystem == null || !target.equalsIgnoreCase(ecosystem.trim())) {
                 String deviceName = placedDevice.getDevice().getName();
 
-                return new ValidationResult(false, "ERROR", "Device-ul '" + deviceName + "' nu este compatibil cu ecosistemul țintă '" + target + "'.");
+                return new ValidationResult(false, "ERROR", "'" + deviceName + "' is not compatible with '" + target + "' ecosystem.");
             }
         }
 
-        return new ValidationResult(true, "INFO", "Toate device-urile sunt compatibile cu ecosistemul țintă.");
+        return new ValidationResult(true, "INFO", "All devices are compatible with given ecosystem.");
     }
 }

--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/HubRequirementRule.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/HubRequirementRule.java
@@ -9,11 +9,11 @@ public class HubRequirementRule implements IValidationRule {
     @Override
     public ValidationResult validate(SetupBuild build) {
         if (build == null) {
-            return new ValidationResult(false, "ERROR", "SetupBuild este null.");
+            return new ValidationResult(false, "ERROR", "SetupBuild is null.");
         }
 
         if (build.getDevices() == null || build.getDevices().isEmpty()) {
-            return new ValidationResult(true, "INFO", "Nu există device-uri de verificat.");
+            return new ValidationResult(true, "INFO", "There are no devices to be checked.");
         }
 
         boolean hasHub = false;
@@ -43,9 +43,9 @@ public class HubRequirementRule implements IValidationRule {
         }
 
         if (requiresHub && !hasHub) {
-            return new ValidationResult(false, "ERROR", "Există device-uri care necesită hub, dar nu a fost găsit niciun hub în setup.");
+            return new ValidationResult(false, "ERROR", "There are devices that need a hub, but no hub has been found in this layout.");
         }
 
-        return new ValidationResult(true, "INFO", "Cerința de hub este îndeplinită.");
+        return new ValidationResult(true, "INFO", "Hub requirements are met.");
     }
 }

--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/HubRequirementRule.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/HubRequirementRule.java
@@ -1,0 +1,51 @@
+package gr.A4.SmartHouseBuilder.engine;
+
+import gr.A4.SmartHouseBuilder.model.PlacedDevice;
+import gr.A4.SmartHouseBuilder.model.SetupBuild;
+import gr.A4.SmartHouseBuilder.model.ValidationResult;
+
+public class HubRequirementRule implements IValidationRule {
+
+    @Override
+    public ValidationResult validate(SetupBuild build) {
+        if (build == null) {
+            return new ValidationResult(false, "ERROR", "SetupBuild este null.");
+        }
+
+        if (build.getDevices() == null || build.getDevices().isEmpty()) {
+            return new ValidationResult(true, "INFO", "Nu există device-uri de verificat.");
+        }
+
+        boolean hasHub = false;
+        boolean requiresHub = false;
+
+        for (PlacedDevice placedDevice : build.getDevices()) {
+            if (placedDevice == null || placedDevice.getDevice() == null) {
+                continue;
+            }
+
+            String name = placedDevice.getDevice().getName();
+            String deviceType = placedDevice.getDevice().getDeviceType();
+
+            if ((name != null && name.toLowerCase().contains("hub")) ||
+                (deviceType != null && deviceType.toLowerCase().contains("hub"))) {
+                hasHub = true;
+            }
+
+            // Heuristică simplă: anumite device-uri pot avea nevoie de hub
+            String protocol = placedDevice.getDevice().getProtocol();
+            if (protocol != null) {
+                String normalized = protocol.toLowerCase();
+                if (normalized.contains("zigbee") || normalized.contains("zwave") || normalized.contains("z-wave")) {
+                    requiresHub = true;
+                }
+            }
+        }
+
+        if (requiresHub && !hasHub) {
+            return new ValidationResult(false, "ERROR", "Există device-uri care necesită hub, dar nu a fost găsit niciun hub în setup.");
+        }
+
+        return new ValidationResult(true, "INFO", "Cerința de hub este îndeplinită.");
+    }
+}

--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/IValidationRule.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/engine/IValidationRule.java
@@ -1,0 +1,8 @@
+package gr.A4.SmartHouseBuilder.engine;
+
+import gr.A4.SmartHouseBuilder.model.SetupBuild;
+import gr.A4.SmartHouseBuilder.model.ValidationResult;
+
+public interface IValidationRule {
+    public ValidationResult validate(SetupBuild build);
+}

--- a/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/service/LayoutIntegrationService.java
+++ b/Backend/SmartHouseBuilder/src/main/java/gr/A4/SmartHouseBuilder/service/LayoutIntegrationService.java
@@ -1,0 +1,24 @@
+package gr.A4.SmartHouseBuilder.service;
+
+import gr.A4.SmartHouseBuilder.engine.CompatibilityEngine;
+import gr.A4.SmartHouseBuilder.model.SetupBuild;
+import gr.A4.SmartHouseBuilder.model.ValidationResult;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor
+@Service
+public class LayoutIntegrationService {
+
+    private final CompatibilityEngine compatibilityEngine;
+
+    public List<ValidationResult> integrateAndVerify(SetupBuild build) {
+
+        List<ValidationResult> finalResults = new ArrayList<>(compatibilityEngine.runAllChecks(build));
+
+        return finalResults;
+    }
+}


### PR DESCRIPTION
Implemented the compatibility engine logic for the "/validate-layout" API endpoint. To properly use the api endpoint, a valid buildlayout must be provided to the "/api/validate-layout" endpoint. It will return a json list of validation results, each with fields "severityLevel"(string),"message"(The message that should be displayed) and "valid"(boolean) that tells if the given BuildLayout is valid all throughout or not. Also needs the "feature/preluare-si-parsare-layout" branch to be integrated to work properly (has dependencies in that branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic validation of smart home setups to verify device compatibility with the selected ecosystem
  * Implemented hub requirement detection to ensure necessary hub devices are included based on device connectivity protocols

<!-- end of auto-generated comment: release notes by coderabbit.ai -->